### PR TITLE
Add redirect URL & update SurveyStatusMessage

### DIFF
--- a/src/app/components/ProgressBar.tsx
+++ b/src/app/components/ProgressBar.tsx
@@ -8,12 +8,12 @@ interface ProgressBarProps {
 /**
  * ProgressBar component displays a horizontal progress bar indicating the completion percentage.
  * @param progress - Completion percentage from 0 to 100
- * @param className - Optional additional CSS classes for styling
+ * @param className - Optional additional CSS classes for styling the progress bar
  */
 export const ProgressBar: React.FC<ProgressBarProps> = ({progress, className}) => (
-    <div className={`h-2 bg-gray-200 rounded-t-2xl overflow-hidden progress-bar ${className || ''}`}>
+    <div className={`h-2 bg-gray-200 rounded-t-2xl overflow-hidden progress-bar`}>
         <div
-            className="h-full bg-blue-600 transition-all duration-300"
+            className={`h-full transition-all duration-300 ${className || 'bg-blue-600'}`}
             style={{width: `${progress}%`}}
         ></div>
     </div>

--- a/src/app/components/SurveyStatusMessage.tsx
+++ b/src/app/components/SurveyStatusMessage.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import React from "react";
+import {Info, ArrowLeft, Mail, AlertTriangle, Smile} from "lucide-react";
+import Link from "next/link";
 import {ProgressBar} from "./ProgressBar";
-import {ArrowLeft} from "lucide-react";
+import {SurveyStatusType} from "../utils/types";
 
 interface SurveyStatusMessageProps {
     title: string;
@@ -10,7 +12,14 @@ interface SurveyStatusMessageProps {
     message: string;
     showStudyTitle?: boolean;
     isNotFound?: boolean;
+    type?: SurveyStatusType;
 }
+
+const iconMap = {
+    [SurveyStatusType.Success]: <Smile className="w-12 h-12 text-green-500 mb-4" aria-hidden="true"/>,
+    [SurveyStatusType.Error]: <AlertTriangle className="w-12 h-12 text-red-500 mb-4" aria-hidden="true"/>,
+    [SurveyStatusType.Info]: <Info className="w-12 h-12 text-blue-500 mb-4" aria-hidden="true"/>,
+};
 
 /**
  * SurveyStatusMessage component displays a message at the end of the survey or for special pages like 404.
@@ -19,6 +28,7 @@ interface SurveyStatusMessageProps {
  * @param message - The main message content to display to the user.
  * @param showStudyTitle - Optional flag to show the study title at the top.
  * @param isNotFound - Optional flag to style for 404 pages (red progress bar/title, custom footer).
+ * @param type - The type of message, can be "success", "error", or "info". Defaults to "info".
  */
 export function SurveyStatusMessage(
     {
@@ -27,6 +37,7 @@ export function SurveyStatusMessage(
         message,
         showStudyTitle = false,
         isNotFound = false,
+        type,
     }: SurveyStatusMessageProps) {
 
     // Handler for going back
@@ -37,39 +48,62 @@ export function SurveyStatusMessage(
         }
     }
 
+    // Determine icon and color
+    const resolvedType = type || SurveyStatusType.Info;
+    const icon = iconMap[resolvedType];
+    const titleColor = resolvedType === SurveyStatusType.Error ? "text-red-700" : resolvedType === SurveyStatusType.Success ? "text-green-700" : "text-blue-700";
+    const subtitleColor = resolvedType === SurveyStatusType.Error ? "text-red-600" : "text-gray-800";
+    const progressBarColor = resolvedType === SurveyStatusType.Error ? "bg-red-500" : resolvedType === SurveyStatusType.Success ? "bg-green-500" : "bg-blue-500";
+
     return (
-        <main className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4 text-center">
+        <main className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4 text-center"
+              aria-live="polite" role="status">
             {showStudyTitle && (
-                <h1 className={`text-2xl font-bold text-black mb-8`}>
+                <h1 className="text-2xl font-bold text-black mb-8 tracking-tight drop-shadow-sm">
                     Prolific Python Error Fixing Study
                 </h1>
             )}
-            <div className="w-full max-w-3xl bg-white rounded-2xl card-shadow p-8 relative fade-in">
-                {!isNotFound && (
-                    <div className="absolute top-0 left-0 w-full h-2 z-10">
-                        <ProgressBar progress={100}/>
-                    </div>
-                )}
-                <h1 className={`text-3xl font-bold mb-6 ${isNotFound ? "text-red-700" : "text-green-700"}`}>{title}</h1>
-                <h2 className={`text-lg font-semibold mb-4 ${isNotFound ? "text-red-600" : "text-gray-800"}`}>
-                    {isNotFound ? "" : subtitle}
-                </h2>
-                <p className="mb-6 text-gray-700">{message}</p>
-                <div className={`text-gray-500 text-sm mt-8`}>
-                    {isNotFound ? (
-                        <div className="flex justify-center">
-                            <button
-                                onClick={handleGoBack}
-                                className="cursor-pointer px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition flex items-center gap-2"
-                            >
-                                <ArrowLeft className="w-5 h-5"/>
-                                Go Back
-                            </button>
-                        </div>
-                    ) : (
-                        "You may now close this window."
-                    )}
+            <div className="w-full max-w-3xl bg-white rounded-2xl card-shadow p-8 relative fade-in animate-fadeIn"
+                 style={{boxShadow: "0 4px 24px rgba(0,0,0,0.08)"}}>
+
+                {/* Progress bar at the top */}
+                <div className="absolute top-0 left-0 w-full z-10">
+                    <ProgressBar progress={100} className={progressBarColor}/>
                 </div>
+
+                {/* Title and subtitle section with icon*/}
+                <div className="flex flex-col items-center">
+                    {icon}
+                    <h1 className={`text-3xl font-bold mb-2 ${titleColor}`}>{title}</h1>
+                    {subtitle && (
+                        <h2 className={`text-lg font-semibold mb-4 ${subtitleColor}`}>{subtitle}</h2>
+                    )}
+                    <p className="mb-6 text-gray-700 max-w-xl">{message}</p>
+                </div>
+
+                {/* Action buttons section */}
+                <div className="flex flex-col gap-3 items-center mt-4">
+                    {isNotFound ? (
+                        <button
+                            onClick={handleGoBack}
+                            className="cursor-pointer px-5 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition flex items-center gap-2 focus:outline-none focus:ring-2 focus:ring-red-400"
+                            aria-label="Go Back"
+                        >
+                            <ArrowLeft className="w-5 h-5"/>
+                            Go Back
+                        </button>
+                    ) : null}
+                </div>
+                {!isNotFound && (
+                    <div className="text-gray-500 text-sm mt-8">You may now close this window.</div>
+                )}
+            </div>
+            <div className="mt-6 text-xs text-gray-400 flex items-center gap-2">
+                <Mail className="w-4 h-4"/>
+                For support, please contact
+                <Link href="mailto:amoraru@tudelft.nl" className="underline hover:text-blue-600">
+                    amoraru@tudelft.nl
+                </Link>
             </div>
         </main>
     );

--- a/src/app/missing-prolific-id/page.tsx
+++ b/src/app/missing-prolific-id/page.tsx
@@ -1,5 +1,6 @@
 import {SurveyStatusMessage} from "../components/SurveyStatusMessage";
 import React from "react";
+import {SurveyStatusType} from "@/app/utils/types";
 
 /**
  * This component displays a message when the user tries to access the study without a Prolific ID.
@@ -13,6 +14,7 @@ export default function MissingProlificId() {
             message="You must access this study using your personalized Prolific link. Please return to Prolific and use the provided link to participate."
             showStudyTitle={true}
             isNotFound={true}
+            type={SurveyStatusType.Error}
         />
     );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,6 @@
 import {SurveyStatusMessage} from "./components/SurveyStatusMessage";
 import React from "react";
+import {SurveyStatusType} from "./utils/types";
 
 /**
  * NotFound component displays a 404 page not found message when the user navigates to a non-existent route.
@@ -13,6 +14,7 @@ export default function NotFound() {
             for correctness. Click on the button below to go back."
             showStudyTitle={true}
             isNotFound={true}
+            type={SurveyStatusType.Error}
         />
     );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, {useState, useEffect} from "react";
-import {Part1Answers} from "@/app/utils/types";
+import {Part1Answers, SurveyStatusType} from "@/app/utils/types";
 import {ProgressBar} from "./components/ProgressBar";
 import {Part1Survey} from "./components/Part1Survey";
 import {Part2Survey} from "./components/Part2Survey";
@@ -60,8 +60,10 @@ export default function App() {
             <SurveyStatusMessage
                 title="Thank you for your time!"
                 subtitle="You have chosen not to participate."
-                message="Your choice has been recorded."
+                message="Because you have not consented, you will not be able to participate
+                in this study and will not receive any compensation. Your choice has been recorded."
                 showStudyTitle={true}
+                type={SurveyStatusType.Info}
             />
         );
     }
@@ -94,10 +96,11 @@ export default function App() {
     if (snippetIdx >= 4) {
         return (
             <SurveyStatusMessage
-                title="Thank you for your consideration!"
+                title="Thank you for your time!"
                 subtitle="You have completed the survey."
                 message="We appreciate your effort and attention in helping us improve code understanding and error fixing. Your responses have been recorded."
                 showStudyTitle={true}
+                type={SurveyStatusType.Success}
             />
         );
     }

--- a/src/app/utils/types.ts
+++ b/src/app/utils/types.ts
@@ -30,3 +30,12 @@ export interface CodeSnippet {
     code: string;
     error: string;
 }
+
+/**
+ * Enum representing the possible status types for the survey status message.
+ */
+export enum SurveyStatusType {
+    Success = "success",
+    Error = "error",
+    Info = "info"
+}


### PR DESCRIPTION
This PR adds support for redirecting users whenever they do not have their PROLIFIC_ID in the URL. Additionally, it also improves the UI for the SurveyStatusMessage to better reflect states.